### PR TITLE
Fix MP4 chunk offset to point to media data

### DIFF
--- a/ScreenRecordingStudio.Core/Services/TrueMP4Encoder.cs
+++ b/ScreenRecordingStudio.Core/Services/TrueMP4Encoder.cs
@@ -18,6 +18,7 @@ namespace ScreenRecordingStudio.Core.Services
         private readonly object _lockObject = new();
         private int _width, _height;
         private DateTime _startTime;
+        private long _mdatDataOffset;
 
         public bool IsEncoding => _isEncoding;
 
@@ -169,6 +170,7 @@ namespace ScreenRecordingStudio.Core.Services
             var mdatStart = writer.BaseStream.Position;
             WriteUInt32BE(writer, 0); // Size placeholder
             WriteStringBE(writer, "mdat"); // Type
+            _mdatDataOffset = writer.BaseStream.Position; // Actual media data offset
 
             // Write all frame data
             foreach (var frameData in _frameData)
@@ -432,7 +434,7 @@ namespace ScreenRecordingStudio.Core.Services
             WriteStringBE(writer, "stco"); // Type
             WriteUInt32BE(writer, 0); // Version and flags
             WriteUInt32BE(writer, 1); // Entry count
-            WriteUInt32BE(writer, 32); // Chunk offset (mdat starts at byte 32)
+            WriteUInt32BE(writer, (uint)_mdatDataOffset); // Chunk offset (start of mdat data)
         }
 
         private void UpdateMdatSize(BinaryWriter writer, long mdatPosition)


### PR DESCRIPTION
## Summary
- track the actual `mdat` data offset when assembling MP4 files in the managed encoder
- emit the recorded offset in the chunk-offset atom so video readers can locate the encoded frames

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4b541d7c08323b3b209d921283aa2